### PR TITLE
feat: Use production directory directly without copying to .generated

### DIFF
--- a/e2e/src/nx-supabase.spec.ts
+++ b/e2e/src/nx-supabase.spec.ts
@@ -157,7 +157,9 @@ describe('@gridatek/nx-supabase', () => {
 
       // Verify build worked and generated files
       expect(existsSync(join(projectPath, '.generated', 'local'))).toBe(true);
-      expect(existsSync(join(projectPath, '.generated', 'production'))).toBe(true);
+      // Production should NOT be in .generated - it uses production/ directly
+      expect(existsSync(join(projectPath, '.generated', 'production'))).toBe(false);
+      expect(existsSync(join(projectPath, 'production', 'config.toml'))).toBe(true);
 
       // Verify other inferred targets are also available (start, stop, run-command)
       // Test that we can run status command (non-Docker command that works in any environment)
@@ -204,13 +206,14 @@ describe('@gridatek/nx-supabase', () => {
         }
       );
 
-      // Verify .generated directories were created for each environment
+      // Verify .generated directories were created for non-production environments
       expect(existsSync(join(projectPath, '.generated', 'local'))).toBe(true);
-      expect(existsSync(join(projectPath, '.generated', 'production'))).toBe(true);
+      // Production should NOT be in .generated - it uses production/ directly
+      expect(existsSync(join(projectPath, '.generated', 'production'))).toBe(false);
 
-      // Verify config.toml files were built (these are the actual files that get created)
+      // Verify config.toml files exist
       expect(existsSync(join(projectPath, '.generated', 'local', 'config.toml'))).toBe(true);
-      expect(existsSync(join(projectPath, '.generated', 'production', 'config.toml'))).toBe(true);
+      expect(existsSync(join(projectPath, 'production', 'config.toml'))).toBe(true);
     });
   });
 

--- a/packages/nx-supabase/src/executors/run-command/run-command.spec.ts
+++ b/packages/nx-supabase/src/executors/run-command/run-command.spec.ts
@@ -96,7 +96,8 @@ describe.skip('Supabase Executor', () => {
   it('should use specified environment', async () => {
     // Create test structure
     const projectRoot = join(testRoot, 'apps/test-project');
-    const prodDir = join(projectRoot, '.generated', 'production');
+    // Production uses production/ directly, not .generated/production
+    const prodDir = join(projectRoot, 'production');
     mkdirSync(prodDir, { recursive: true });
     writeFileSync(join(prodDir, 'config.toml'), 'test config');
 

--- a/packages/nx-supabase/src/generators/project/project.ts
+++ b/packages/nx-supabase/src/generators/project/project.ts
@@ -66,9 +66,9 @@ ${projectRoot}/
 
 ## How it Works
 
-- **production/** - Your production Supabase configuration (base config for all environments)
+- **production/** - Your production Supabase configuration (base config for all environments, used directly without copying)
 - **local/** - Local development overrides (empty by default, only add what's different from production)
-- **.generated/** - Build output. For production: copies production/. For other envs: merges production + env overrides
+- **.generated/** - Build output for non-production environments (merges production + env overrides)
 
 ## Usage
 


### PR DESCRIPTION
- Modified build executor to skip copying production to .generated/production
- Production environment now uses production/ directory directly
- Other environments still build to .generated/<env> with merged files
- Updated run-command executor to handle production differently
- Updated all tests to verify production is NOT in .generated/
- Updated documentation to reflect new behavior

This optimization eliminates unnecessary file copying for production environment while maintaining the merge functionality for other environments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)