### PR TITLE
feat: Always create production and local environments by default

### DIFF
--- a/e2e/src/nx-supabase.spec.ts
+++ b/e2e/src/nx-supabase.spec.ts
@@ -83,11 +83,11 @@ describe('@gridatek/nx-supabase', () => {
       expect(existsSync(join(projectPath, '.generated'))).toBe(true);
     });
 
-    it('should create a project with multiple environments', () => {
+    it('should create a project with additional environments', () => {
       const projectName = 'multi-env-project';
 
       execSync(
-        `npx nx g @gridatek/nx-supabase:project ${projectName} --environments=local,staging,production`,
+        `npx nx g @gridatek/nx-supabase:project ${projectName} --environments=staging`,
         {
           cwd: projectDirectory,
           stdio: 'inherit',
@@ -97,11 +97,15 @@ describe('@gridatek/nx-supabase', () => {
 
       const projectPath = join(projectDirectory, projectName);
 
-      // Verify all environments were created
-      ['local', 'staging', 'production'].forEach(env => {
-        expect(existsSync(join(projectPath, env, 'migrations'))).toBe(true);
-        expect(existsSync(join(projectPath, env, 'seeds'))).toBe(true);
-      });
+      // Verify production and local are always created
+      expect(existsSync(join(projectPath, 'production', 'migrations'))).toBe(true);
+      expect(existsSync(join(projectPath, 'production', 'seeds'))).toBe(true);
+      expect(existsSync(join(projectPath, 'local', 'migrations'))).toBe(true);
+      expect(existsSync(join(projectPath, 'local', 'seeds'))).toBe(true);
+
+      // Verify additional environment (staging) was created
+      expect(existsSync(join(projectPath, 'staging', 'migrations'))).toBe(true);
+      expect(existsSync(join(projectPath, 'staging', 'seeds'))).toBe(true);
     });
 
     it('should create project in custom directory', () => {
@@ -184,9 +188,9 @@ describe('@gridatek/nx-supabase', () => {
     it('should build default and environment-specific files', () => {
       const projectName = 'build-test-project';
 
-      // Create a project with multiple environments
+      // Create a project (production and local are created by default)
       execSync(
-        `npx nx g @gridatek/nx-supabase:project ${projectName} --environments=local,production`,
+        `npx nx g @gridatek/nx-supabase:project ${projectName}`,
         {
           cwd: projectDirectory,
           stdio: 'inherit',
@@ -222,9 +226,9 @@ describe('@gridatek/nx-supabase', () => {
     it('should start and stop Supabase using convenient shortcuts', async () => {
       const projectName = 'start-stop-test-project';
 
-      // Create a project with local environment
+      // Create a project (production and local are created by default)
       execSync(
-        `npx nx g @gridatek/nx-supabase:project ${projectName} --environments=local`,
+        `npx nx g @gridatek/nx-supabase:project ${projectName}`,
         {
           cwd: projectDirectory,
           stdio: 'inherit',
@@ -340,9 +344,9 @@ describe('@gridatek/nx-supabase', () => {
     it('should start and stop project without project.json via inferred tasks', async () => {
       const projectName = 'no-project-json-start-stop';
 
-      // Create a project without project.json
+      // Create a project without project.json (production and local are created by default)
       execSync(
-        `npx nx g @gridatek/nx-supabase:project ${projectName} --environments=local --skipProjectJson`,
+        `npx nx g @gridatek/nx-supabase:project ${projectName} --skipProjectJson`,
         {
           cwd: projectDirectory,
           stdio: 'inherit',

--- a/packages/nx-supabase/src/generators/project/project.spec.ts
+++ b/packages/nx-supabase/src/generators/project/project.spec.ts
@@ -69,24 +69,24 @@ describe('project generator', () => {
     expect(tree.exists('test/local/seeds/.gitkeep')).toBeTruthy();
   });
 
-  it('should create multiple environments when specified', async () => {
+  it('should create additional environments beyond production and local', async () => {
     const optionsWithEnvs: ProjectGeneratorSchema = {
       name: 'test',
-      environments: 'local,staging,production',
+      environments: 'staging,dev',
     };
     await projectGenerator(tree, optionsWithEnvs);
 
-    // Check local environment
+    // Production and local should always be created
+    expect(tree.exists('test/production/migrations/.gitkeep')).toBeTruthy();
+    expect(tree.exists('test/production/seeds/.gitkeep')).toBeTruthy();
     expect(tree.exists('test/local/migrations/.gitkeep')).toBeTruthy();
     expect(tree.exists('test/local/seeds/.gitkeep')).toBeTruthy();
 
-    // Check staging environment
+    // Additional environments should also be created
     expect(tree.exists('test/staging/migrations/.gitkeep')).toBeTruthy();
     expect(tree.exists('test/staging/seeds/.gitkeep')).toBeTruthy();
-
-    // Check production environment
-    expect(tree.exists('test/production/migrations/.gitkeep')).toBeTruthy();
-    expect(tree.exists('test/production/seeds/.gitkeep')).toBeTruthy();
+    expect(tree.exists('test/dev/migrations/.gitkeep')).toBeTruthy();
+    expect(tree.exists('test/dev/seeds/.gitkeep')).toBeTruthy();
   });
 
   it('should skip project.json when skipProjectJson is true', async () => {

--- a/packages/nx-supabase/src/generators/project/project.ts
+++ b/packages/nx-supabase/src/generators/project/project.ts
@@ -108,15 +108,21 @@ nx run ${options.name}:run-command --env=local --command="supabase db reset"
   tree.write(`${projectRoot}/production/migrations/.gitkeep`, '');
   tree.write(`${projectRoot}/production/seeds/.gitkeep`, '');
 
-  // Parse environments from comma-separated string
-  // Default to local environment
-  const envList = (options.environments || 'local')
-    .split(',')
-    .map(env => env.trim())
-    .filter(env => env.length > 0 && env !== 'production'); // Exclude production since it's always created
+  // Always create local environment (default dev environment)
+  logger.info('Creating local environment...');
+  tree.write(`${projectRoot}/local/migrations/.gitkeep`, '');
+  tree.write(`${projectRoot}/local/seeds/.gitkeep`, '');
+
+  // Parse additional environments from comma-separated string (beyond production and local)
+  const additionalEnvs = options.environments
+    ? options.environments
+        .split(',')
+        .map(env => env.trim())
+        .filter(env => env.length > 0 && env !== 'production' && env !== 'local') // Exclude production and local since they're always created
+    : [];
 
   // Create each additional environment as empty directories
-  for (const envName of envList) {
+  for (const envName of additionalEnvs) {
     logger.info(`Creating ${envName} environment...`);
     const envDirectories = [
       `${projectRoot}/${envName}/migrations`,
@@ -128,8 +134,8 @@ nx run ${options.name}:run-command --env=local --command="supabase db reset"
     }
   }
 
-  // Add production back to envList for logging purposes
-  const allEnvs = ['production', ...envList];
+  // Build complete list of all environments for logging purposes
+  const allEnvs = ['production', 'local', ...additionalEnvs];
 
   await formatFiles(tree);
 

--- a/packages/nx-supabase/src/generators/project/schema.json
+++ b/packages/nx-supabase/src/generators/project/schema.json
@@ -20,8 +20,7 @@
     },
     "environments": {
       "type": "string",
-      "description": "Comma-separated list of environments to create (default: local)",
-      "default": "local"
+      "description": "Comma-separated list of additional environments to create beyond production and local (e.g., staging,dev)"
     },
     "skipProjectJson": {
       "type": "boolean",


### PR DESCRIPTION
- Production and local environments are now always created by default
- The --environments flag now only specifies additional environments beyond production and local
- Updated schema description to clarify that environments are for additional envs only
- Removed default value from environments schema since production and local are automatic
- Updated all tests to reflect new behavior
- Simplified e2e tests to remove redundant --environments flags

This change improves the user experience by:
1. Making the default setup more intuitive (production + local always exist)
2. Simplifying the --environments flag to only handle additional environments
3. Reducing confusion about which environments need to be specified

Examples:
- No flag: Creates production + local
- --environments=staging: Creates production + local + staging
- --environments=staging,dev: Creates production + local + staging + dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)