### PR TITLE
feat: Include LICENSE file in npm package build

### DIFF
--- a/packages/nx-supabase/package.json
+++ b/packages/nx-supabase/package.json
@@ -48,6 +48,11 @@
               "input": "./packages/nx-supabase/src",
               "glob": "**/*.d.ts",
               "output": "."
+            },
+            {
+              "input": ".",
+              "glob": "LICENSE",
+              "output": "."
             }
           ]
         }
@@ -63,7 +68,8 @@
     "dist",
     "!**/*.tsbuildinfo",
     "generators.json",
-    "executors.json"
+    "executors.json",
+    "LICENSE"
   ],
   "executors": "./executors.json"
 }


### PR DESCRIPTION
- Added LICENSE file from root to build assets
- LICENSE file is now copied to dist/ during build
- Added LICENSE to files array for npm package inclusion

This ensures the MIT license is properly distributed with the npm package when published, providing proper legal attribution and terms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)