### PR TITLE
fix: Copy package.json to dist during build

### DIFF
--- a/packages/nx-supabase/package.json
+++ b/packages/nx-supabase/package.json
@@ -68,6 +68,11 @@
               "input": "./packages/nx-supabase",
               "glob": "executors.json",
               "output": "."
+            },
+            {
+              "input": "./packages/nx-supabase",
+              "glob": "package.json",
+              "output": "."
             }
           ]
         }


### PR DESCRIPTION
- Add package.json to build assets so it's available in dist folder
- This ensures nx release can publish with correct files array
- Resolves issue where only 3 files were published to npm