### PR TITLE
fix: remove failing nx fix-ci step from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,3 @@ jobs:
       - run: npx nx e2e e2e
         env:
           CI: true
-
-      # Nx Cloud recommends fixes for failures to help you get CI green faster. Learn more: https://nx.dev/ci/features/self-healing-ci
-      - run: npx nx fix-ci
-        if: always()


### PR DESCRIPTION
The nx fix-ci command was causing CI failures. Removed this step as it's not critical for the build process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)