### PR TITLE
fix: update Supabase CLI version to ^2.67.3 and centralize version ma…

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -38,7 +38,7 @@ npx nx g @gridatek/nx-supabase:init [options]
 
 **What it does:**
 
-1. Adds `supabase` CLI (^2.65.6) to devDependencies (unless `--skipPackageJson` is true)
+1. Adds `supabase` CLI (^2.67.3) to devDependencies (unless `--skipPackageJson` is true)
 2. Registers `@gridatek/nx-supabase` plugin in `nx.json`
 3. Returns a callback to install dependencies
 

--- a/e2e/src/nx-supabase.spec.ts
+++ b/e2e/src/nx-supabase.spec.ts
@@ -1,6 +1,7 @@
 import { execSync, spawn } from 'child_process';
 import { join, dirname } from 'path';
 import { mkdirSync, rmSync, existsSync } from 'fs';
+import { SUPABASE_CLI_VERSION } from '../../packages/nx-supabase/src/versions';
 
 describe('@gridatek/nx-supabase', () => {
   let projectDirectory: string;
@@ -44,7 +45,7 @@ describe('@gridatek/nx-supabase', () => {
 
       const packageJson = require(packageJsonPath);
       expect(packageJson.devDependencies['supabase']).toBeDefined();
-      expect(packageJson.devDependencies['supabase']).toBe('^2.65.6');
+      expect(packageJson.devDependencies['supabase']).toBe(SUPABASE_CLI_VERSION);
     });
   });
 

--- a/e2e/tsconfig.spec.json
+++ b/e2e/tsconfig.spec.json
@@ -9,6 +9,7 @@
     "jest.config.cts",
     "src/**/*.test.ts",
     "src/**/*.spec.ts",
-    "src/**/*.d.ts"
+    "src/**/*.d.ts",
+    "../packages/nx-supabase/src/versions.ts"
   ]
 }

--- a/npm-e2e/src/npm-install.spec.ts
+++ b/npm-e2e/src/npm-install.spec.ts
@@ -1,6 +1,7 @@
 import { execSync } from 'child_process';
 import { join, dirname } from 'path';
 import { mkdirSync, rmSync, existsSync, readFileSync } from 'fs';
+import { SUPABASE_CLI_VERSION } from '../../packages/nx-supabase/src/versions';
 
 describe('@gridatek/nx-supabase npm installation', () => {
   let projectDirectory: string;
@@ -44,7 +45,7 @@ describe('@gridatek/nx-supabase npm installation', () => {
 
       const packageJson = require(packageJsonPath);
       expect(packageJson.devDependencies['supabase']).toBeDefined();
-      expect(packageJson.devDependencies['supabase']).toBe('^2.65.6');
+      expect(packageJson.devDependencies['supabase']).toBe(SUPABASE_CLI_VERSION);
     });
   });
 

--- a/npm-e2e/tsconfig.spec.json
+++ b/npm-e2e/tsconfig.spec.json
@@ -6,6 +6,7 @@
   },
   "include": [
     "jest.config.cts",
-    "src/**/*.ts"
+    "src/**/*.ts",
+    "../packages/nx-supabase/src/versions.ts"
   ]
 }

--- a/packages/nx-supabase/src/generators/init/init.spec.ts
+++ b/packages/nx-supabase/src/generators/init/init.spec.ts
@@ -3,6 +3,7 @@ import { Tree, readJson, readNxJson } from '@nx/devkit';
 
 import { initGenerator } from './init';
 import { InitGeneratorSchema } from './schema';
+import { SUPABASE_CLI_VERSION } from '../../versions';
 
 describe('init generator', () => {
   let tree: Tree;
@@ -16,7 +17,7 @@ describe('init generator', () => {
     await initGenerator(tree, options);
     const packageJson = readJson(tree, 'package.json');
     expect(packageJson.devDependencies['supabase']).toBeDefined();
-    expect(packageJson.devDependencies['supabase']).toBe('^2.65.6');
+    expect(packageJson.devDependencies['supabase']).toBe(SUPABASE_CLI_VERSION);
   });
 
   it('should register the plugin in nx.json', async () => {

--- a/packages/nx-supabase/src/generators/init/init.ts
+++ b/packages/nx-supabase/src/generators/init/init.ts
@@ -8,6 +8,7 @@ import {
   updateNxJson,
 } from '@nx/devkit';
 import { InitGeneratorSchema } from './schema';
+import { SUPABASE_CLI_VERSION } from '../../versions';
 
 export async function initGenerator(
   tree: Tree,
@@ -23,7 +24,7 @@ export async function initGenerator(
       tree,
       {},
       {
-        supabase: '^2.65.6',
+        supabase: SUPABASE_CLI_VERSION,
       }
     );
 

--- a/packages/nx-supabase/src/versions.ts
+++ b/packages/nx-supabase/src/versions.ts
@@ -1,0 +1,4 @@
+/**
+ * Centralized version definitions for external dependencies
+ */
+export const SUPABASE_CLI_VERSION = '^2.67.3';


### PR DESCRIPTION
…nagement

- Create centralized versions.ts file to manage dependency versions in one place
- Update Supabase CLI version from ^2.65.6 to ^2.67.3 to match latest release
- Update all tests to use the centralized SUPABASE_CLI_VERSION constant
- Update TypeScript configs to include versions.ts in e2e and npm-e2e projects
- Update documentation to reflect new version

This fixes the npm-e2e test failures caused by version mismatch between the expected version in tests and the actual version being installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)